### PR TITLE
Adds -binary option to output binary files instead of asm source files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,8 @@ This project is heavily inspired by Maxim's BMP2Tile application https://github.
     -savetmx <filename> 
                          Save tilemap and corresponding tileset in the Tiled
                          mapeditor TMX format.
+    
+    -binary
+                         Output binary files instead of asm source files.
+                         Ignored for sms_cl123 palette format, TMX, and PNG output.
 

--- a/main.cpp
+++ b/main.cpp
@@ -407,7 +407,6 @@ Config parse_commandline_opts(int argc, char **argv) {
                     config.tmx_filename = argv[i];
                 }
             } else if (strcmp(cmd, "binary") == 0) {
-                i++;
                 cfg_output_bin = true;
             } else {
                 printf("Unknown option: '-%s'\n", cmd);


### PR DESCRIPTION
This command line option will allow outputting binary files for tiles, palettes, and tilemaps.
Ignored for sms_cl123 palettes, TMX, and PNG outputs.

The config variable isn't part of the config struct since the palette writing functions don't accept a config object.
