### PR TITLE
Add -compress option for compressing binary output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,17 @@ project(png2tile)
 
 find_package(PNG REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wno-sign-compare")
 
-set(SOURCE_FILES main.cpp)
+set(SOURCE_FILES
+    compressors/gfxcomp_stm.c
+    compressors/gfxcomp_phantasystargaiden.cpp
+    main.cpp
+)
+
 add_executable(png2tile ${SOURCE_FILES})
-
 
 include_directories(${PNG_INCLUDE_DIR})
 target_link_libraries(png2tile ${PNG_LIBRARY} -lz)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ project(png2tile)
 
 find_package(PNG REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(SOURCE_FILES
     compressors/gfxcomp_stm.c
@@ -13,6 +12,7 @@ set(SOURCE_FILES
 )
 
 add_executable(png2tile ${SOURCE_FILES})
+
 
 include_directories(${PNG_INCLUDE_DIR})
 target_link_libraries(png2tile ${PNG_LIBRARY} -lz)

--- a/README.md
+++ b/README.md
@@ -54,11 +54,15 @@ This project is heavily inspired by Maxim's BMP2Tile application https://github.
     -savetileimage <filename>
                          Save tileset data as a PNG image.
     
-    -savetmx <filename> 
+    -savetmx <filename>
                          Save tilemap and corresponding tileset in the Tiled
                          mapeditor TMX format.
     
     -binary
                          Output binary files instead of asm source files.
                          Ignored for sms_cl123 palette format, TMX, and PNG output.
+
+    -compress
+                         Compress output binary files. Uses STM compression for tilemaps
+                         and PSG compression for tiles. Implies -binary if not also specified.
 

--- a/compressors/LICENSE
+++ b/compressors/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Maxim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/compressors/gfxcomp_phantasystargaiden.cpp
+++ b/compressors/gfxcomp_phantasystargaiden.cpp
@@ -1,0 +1,277 @@
+#include <vector>
+#include <map>
+#include <cstdint>
+#include <cstring>
+
+// Forward declares
+void deinterleave(std::vector<uint8_t>& buf, uint32_t interleaving);
+void compressTile(const std::vector<uint8_t>& src, std::vector<uint8_t>& dest);
+
+const char* PSGaiden_getName()
+{
+	// A pretty name for this compression type
+	// Generally, the name of the game it was REd from
+	return "PS Gaiden";
+}
+
+const char* PSGaiden_getExt()
+{
+	// A string suitable for use as a file extension
+	return "psgcompr";
+}
+
+int PSGaiden_compressTiles(uint8_t* source, uint32_t numTiles, uint8_t* dest, uint32_t destLength)
+{
+	if (numTiles > 0xffff)
+	{
+		return -1; // error
+	}
+	std::vector<uint8_t> buf; // the output
+	buf.reserve(destLength); // avoid reallocation
+
+	// Write number of tiles
+	buf.push_back((numTiles >> 0) & 0xff);
+	buf.push_back((numTiles >> 8) & 0xff);
+
+	std::vector<uint8_t> tile;
+	tile.resize(32); // zero fill
+	for (uint32_t i = 0; i < numTiles; ++i)
+	{
+		// Get tile into buffer
+		std::copy(source, source + 32, tile.begin());
+		source += 32;
+		// Deinterleave it
+		deinterleave(tile, 4);
+		// Compress it to dest
+		compressTile(tile, buf);
+	}
+
+	// check length
+	if (buf.size() > destLength)
+	{
+		return 0;
+	}
+	// copy to dest
+	memcpy(dest, &buf[0], buf.size());
+	// return length
+	return buf.size();
+}
+
+void deinterleave(std::vector<uint8_t>& buf, uint32_t interleaving)
+{
+	std::vector<uint8_t> tempbuf(buf.size());
+
+	// Deinterleave into tempbuf
+	int bitplanesize = buf.size() / interleaving;
+	for (unsigned int src = 0; src < buf.size(); ++src)
+	{
+		// If interleaving is 4 I want to turn
+		// AbcdEfghIjklMnopQrstUvwx
+		// into
+		// AEIMQUbfjnrvcgkoswdhlptx
+		// so for a char at position x
+		// x div 4 = offset within this section
+		// x mod 4 = which section
+		// final position = (x div 4) + (x mod 4) * (section size)
+		unsigned int dest = src / interleaving + (src % interleaving) * bitplanesize;
+		tempbuf[dest] = buf[src];
+	}
+
+	// Copy results over the original data
+	std::copy(tempbuf.begin(), tempbuf.end(), buf.begin());
+}
+
+void findMostCommonValue(std::vector<uint8_t>::const_iterator data, uint8_t& value, int& count)
+{
+	std::map<uint8_t, int> counts;
+	// count occurences of each value
+	for (int i = 0; i < 8; ++i)
+	{
+		uint8_t val = *data++;
+		counts[val]++;
+	}
+	// find the highest count and its value
+	count = 0;
+	for (auto& pair: counts)
+	{
+		if (pair.second > count)
+		{
+			value = pair.first;
+			count = pair.second;
+		}
+	}
+}
+
+int countMatches(std::vector<uint8_t>::const_iterator me, std::vector<uint8_t>::const_iterator other, bool invert)
+{
+	int count = 0;
+	int mask = invert ? 0xff : 0x00;
+	for (int i = 0; i < 8; ++i)
+	{
+		if (*me++ == (*other++ ^ mask))
+		{
+			++count;
+		}
+	}
+	return count;
+}
+
+void compressTile(const std::vector<uint8_t>& src, std::vector<uint8_t>& dest)
+{
+	uint8_t bitplaneMethods = 0;
+
+	// compress the tile data into a temporary buffer
+	// because we need to build the method byte before outputting to dest
+	std::vector<uint8_t> tiledata;
+
+	// for each bitplane
+	for (int bitplaneIndex = 0; bitplaneIndex < 4; ++bitplaneIndex)
+	{
+		// Find the most common value in this bitplane
+		uint8_t mostCommonByte;
+		int mostCommonByteCount;
+		std::vector<uint8_t>::const_iterator itBitplane = src.begin() + bitplaneIndex * 8;
+		findMostCommonValue(itBitplane, mostCommonByte, mostCommonByteCount);
+
+		// Find how much it matches previous bitplanes
+		uint8_t otherBitplaneMatchIndex = 0; // which bitplane
+		int otherBitplaneMatchCount = 0; // how many matched
+		bool otherBitplaneMatchInverse = false; // whether it was an inverted match
+		for (uint8_t otherBitplaneIndex = 0; otherBitplaneIndex < bitplaneIndex; ++otherBitplaneIndex)
+		{
+			// Compare
+			std::vector<uint8_t>::const_iterator itOtherBitplane = src.begin() + otherBitplaneIndex * 8;
+			int count = countMatches(itBitplane, itOtherBitplane, false);
+			if (count > otherBitplaneMatchCount)
+			{
+				otherBitplaneMatchIndex = otherBitplaneIndex;
+				otherBitplaneMatchCount = count;
+				otherBitplaneMatchInverse = false;
+			}
+			count = countMatches(itBitplane, itOtherBitplane, true);
+			if (count > otherBitplaneMatchCount)
+			{
+				otherBitplaneMatchIndex = otherBitplaneIndex;
+				otherBitplaneMatchCount = count;
+				otherBitplaneMatchInverse = true;
+			}
+		}
+
+		// Choose method and shift into bitplaneMethods
+		bitplaneMethods <<= 2;
+
+		if (mostCommonByteCount == 8 && mostCommonByte == 0x00)
+		{
+			// all 0 = %00
+			bitplaneMethods |= 0x00;
+			// no data
+		}
+		else if (mostCommonByteCount == 8 && mostCommonByte == 0xff)
+		{
+			// all ff = %01
+			bitplaneMethods |= 0x01;
+			// no data
+		}
+		else if (mostCommonByteCount <= 2 && otherBitplaneMatchCount <= 2)
+		{
+			// raw = %11
+			bitplaneMethods |= 0x03;
+			// output raw data
+			tiledata.insert(tiledata.end(), itBitplane, itBitplane + 8);
+		}
+		else
+		{
+			// compressed = %10
+			bitplaneMethods |= 0x02;
+
+			// select compression type
+			if (otherBitplaneMatchCount == 8)
+			{
+				/// %000f00nn = whole bitplane duplicate
+				if (otherBitplaneMatchInverse)
+				{
+					tiledata.push_back(0x10 | otherBitplaneMatchIndex);
+				}
+				else
+				{
+					tiledata.push_back(0x00 | otherBitplaneMatchIndex);
+				}
+			}
+			else if (otherBitplaneMatchCount > mostCommonByteCount)
+			{
+				/// %001000nn = copy bytes
+				/// %010000nn = copy and invert bytes
+				if (otherBitplaneMatchInverse)
+				{
+					tiledata.push_back(0x40 | otherBitplaneMatchIndex);
+				}
+				else
+				{
+					tiledata.push_back(0x20 | otherBitplaneMatchIndex);
+				}
+
+				// Build bitmask
+				uint8_t bitmask = 0;
+				uint8_t mask = otherBitplaneMatchInverse ? 0xff : 0x00;
+				std::vector<uint8_t>::const_iterator it1 = itBitplane;
+				std::vector<uint8_t>::const_iterator it2 = src.begin() + otherBitplaneMatchIndex * 8;
+				for (int i = 0; i < 8; ++i , ++it1 , ++it2)
+				{
+					bitmask <<= 1;
+					if (*it1 == (*it2 ^ mask))
+					{
+						bitmask |= 1;
+					}
+				}
+
+				// output byte
+				tiledata.push_back(bitmask);
+
+				// output non-matching bytes
+				it1 = itBitplane;
+				it2 = src.begin() + otherBitplaneMatchIndex * 8;
+				for (int i = 0; i < 8; ++i , ++it1 , ++it2)
+				{
+					bitmask <<= 1;
+					if (*it1 != (*it2 ^ mask))
+					{
+						tiledata.push_back(*it1);
+					}
+				}
+			}
+			else
+			{
+				// common byte
+				// build bitmask
+				uint8_t bitmask = 0;
+				std::vector<uint8_t>::const_iterator it = itBitplane;
+				for (int i = 0; i < 8; ++i , ++it)
+				{
+					bitmask <<= 1;
+					if (*it == mostCommonByte)
+					{
+						bitmask |= 1;
+					}
+				}
+				tiledata.push_back(bitmask);
+				tiledata.push_back(mostCommonByte);
+
+				// output non-matching bytes
+				it = itBitplane;
+				for (int i = 0; i < 8; ++i , ++it)
+				{
+					bitmask <<= 1;
+					if (*it != mostCommonByte)
+					{
+						tiledata.push_back(*it);
+					}
+				}
+			} // compression method selection
+		} // method selection
+	} // bitplane loop
+
+	// output
+	dest.push_back(bitplaneMethods);
+	dest.insert(dest.end(), tiledata.begin(), tiledata.end());
+}
+

--- a/compressors/gfxcomp_stm.c
+++ b/compressors/gfxcomp_stm.c
@@ -1,0 +1,189 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#define RLE_TYPE_NORMAL         0x01
+#define RLE_TYPE_INCREMENTAL    0x03
+
+#define HI(x)  ((x)>>8)
+#define LO(x)  ((x)&0xff)
+
+#define MIN_RLE_LEN     2
+#define MAX_RLE_LEN     MIN_RLE_LEN+63
+#define MAX_RAW_LEN     63
+
+int in_size;
+bool shoudchangeHH;
+int current;
+unsigned short int cur_HH;
+unsigned int writepos;
+unsigned short int* buf;
+unsigned char* outbuf;
+unsigned int outsize;
+
+typedef unsigned char uint8_t;
+typedef unsigned int  uint32_t;
+
+
+bool writeRLE (unsigned char val, int cnt, unsigned char type) {
+  unsigned char tmp;
+  tmp=(LO(cnt-MIN_RLE_LEN)<<2)|type;
+  
+  if (writepos<outsize)
+    outbuf[writepos++]=tmp;         // write len
+  else
+    return (false);                 // please give me more space for output
+    
+  if (writepos<outsize)
+    outbuf[writepos++]=val;         // write value
+  else
+    return (false);                 // please give me more space for output
+    
+  return (true);
+}
+
+bool writeHI (unsigned char val, bool temp) {
+  val<<=3;
+  if (temp) val|=0x04;
+  val|=0x02;
+  
+  if (writepos<outsize)
+    outbuf[writepos++]=val;         // write value
+  else
+    return (false);                 // please give me more space for output
+    
+  return (true);
+}
+
+bool checkHI (int i) {
+  // if necessary, check next HH to see if it's worth making it temporary
+  if (shoudchangeHH) {
+    bool temp;
+    if (current+i==in_size) {
+      temp=false;                            // make it permanent, no other check needed (because data is over)
+    } else if (HI(cur_HH)==HI(buf[current+i])) {
+        temp=true;                           // before this run==first of next run
+        if (HI(buf[current+i-1])==HI(buf[current+i])) {
+          temp=false;                        // last of this run==first of next run
+        }
+    } else {
+      temp=false;                            // before this run != first of next run
+    }
+    
+    if (!writeHI(HI(buf[current]),temp))
+      return (false);                       // please give me more space for output
+    if (!temp) cur_HH=buf[current]&0xff00;
+    shoudchangeHH=false;
+  }
+  
+  return (true);
+}
+
+const char* STM_getName() {
+	return "ShrunkTileMap (compressed)";
+}
+
+const char* STM_getExt() {
+	return "stmcompr";
+}
+
+int STM_compressTilemap(uint8_t* source, uint32_t width, uint32_t height, uint8_t* dest, uint32_t destLen) {
+
+  int i,j;
+  unsigned char tmp;
+
+  unsigned int in_size = width*height;
+  buf = (unsigned short int*)source;
+  outbuf = dest;
+  outsize = destLen;
+    
+  shoudchangeHH=false;
+  current=0;
+  cur_HH=0;
+  writepos=0;
+
+  // write header (it's just 1 byte and it stores the width -in tiles- of the map
+  if (writepos<outsize)
+    outbuf[writepos++]=width;     // write map width in tiles
+  else
+    return (0);                   // please give me more space for output
+
+  while (current<in_size) {
+    
+    // check if the HH part of the next tile is the same as what we have
+    if (HI(cur_HH)!=HI(buf[current]))
+      shoudchangeHH=true;
+    
+    if ((current+1<in_size) && (buf[current]==buf[current+1])) {
+      // there are at least 2 equal word values: RLE them
+      
+      for (i=2;i<MAX_RLE_LEN;i++) {
+        if (current+i>=in_size) break;              // leave if data ends
+        if (buf[current]!=buf[current+i]) break;    // leave if no same
+      }
+      
+      if (!checkHI(i))
+        return (0);                                         // please give me more space for output
+      
+      if (!writeRLE(LO(buf[current]),i,RLE_TYPE_NORMAL))
+        return (0);                                         // please give me more space for output
+        
+     
+    } else if ((current+1<in_size) && ((buf[current]+1)==buf[current+1])) {
+      // there are at least 2 successive word values: RLE them
+      
+      for (i=2;i<MAX_RLE_LEN;i++) {
+        if (current+i==in_size) break;                      // leave if data ends
+        if ((buf[current+i-1]+1)!=buf[current+i]) break;   // leave if no successive
+      }
+      
+      cur_HH=buf[current+i-1]&0xff00;                       // make sure we keep the last HH  
+      
+      if (!checkHI(i))
+        return (0);                                         // please give me more space for output
+      
+      if (!writeRLE(LO(buf[current]),i,RLE_TYPE_INCREMENTAL))
+        return (0);                                         // please give me more space for output
+      
+    } else {
+      // there is data we can't RLE. Oh, well...
+      for (i=1;i<MAX_RAW_LEN;i++) {
+        if (current+i==in_size) break;                            // leave if data ends
+        if (buf[current+i-1]==buf[current+i]) {i--; break;}      // leave if found two same
+        if ((buf[current+i-1]+1)==buf[current+i]) {i--; break;}  // leave if found two successive
+        if (HI(buf[current+i-1])!=HI(buf[current+i])) break;     // leave if found different HI part
+      }
+      
+      if (!checkHI(i))
+        return (0);                                         // please give me more space for output
+      
+      tmp=LO(i)<<2;
+
+      if (writepos<outsize)
+        outbuf[writepos++]=tmp;         // write len
+      else
+        return (0);                     // please give me more space for output
+        
+      for (j=0;j<i;j++) {
+        tmp=LO(buf[current+j]);
+        if (writepos<outsize)
+          outbuf[writepos++]=tmp;      // write raw data
+        else
+          return (0);                   // please give me more space for output
+      }
+      
+    }
+    
+    current+=i;
+  
+  }  // end while
+  
+  tmp=0;
+  if (writepos<outsize)
+    outbuf[writepos++]=tmp;         // write end of data
+  else
+    return (0);                     // please give me more space for output
+
+  return (writepos);                // report size to caller
+}

--- a/compressors/gfxcomp_stm.c
+++ b/compressors/gfxcomp_stm.c
@@ -13,9 +13,9 @@
 #define MAX_RLE_LEN     MIN_RLE_LEN+63
 #define MAX_RAW_LEN     63
 
-int in_size;
+unsigned int in_size;
 bool shoudchangeHH;
-int current;
+size_t current;
 unsigned short int cur_HH;
 unsigned int writepos;
 unsigned short int* buf;

--- a/main.cpp
+++ b/main.cpp
@@ -76,10 +76,17 @@ typedef struct {
     int tile_start_offset;
     bool use_sprite_pal;
     bool infront_flag;
+    bool compress;
 } Config;
 
 // global config for binary output option
 static bool cfg_output_bin = false;
+
+// forwards for compressors
+int PSGaiden_compressTiles(uint8_t* source, uint32_t numTiles, uint8_t* dest, uint32_t destLength);
+extern "C" {
+int STM_compressTilemap(uint8_t* source, uint32_t width, uint32_t height, uint8_t* dest, uint32_t destLen);
+}
 
 // PNG read/write logic based on code from Guillaume Cottenceau
 // http://zarb.org/~gc/html/libpng.html
@@ -291,7 +298,11 @@ void show_usage() {
             "\n"
             "-binary \n"
             "                     Output binary files instead of asm source files.\n"
-            "                     Ignored for sms_cl123 palette format, TMX, and PNG output.\n\n";
+            "                     Ignored for sms_cl123 palette format, TMX, and PNG output.\n"
+            "\n"
+            "-compress \n"
+            "                     Compress output binary files. Uses STM compression for tilemaps\n"
+            "                     and PSG compression for tiles. Implies -binary if not also specified.\n\n";
     std::cout << s;
 }
 
@@ -312,6 +323,7 @@ Config parse_commandline_opts(int argc, char **argv) {
     config.use_sprite_pal = false;
     config.infront_flag = false;
     config.tile_start_offset = 0;
+    config.compress = false;
 
     config.output_tile_image_filename = NULL;
     config.tmx_filename = NULL;
@@ -408,6 +420,8 @@ Config parse_commandline_opts(int argc, char **argv) {
                 }
             } else if (strcmp(cmd, "binary") == 0) {
                 cfg_output_bin = true;
+            } else if (strcmp(cmd, "compress") == 0) {
+                config.compress = true;
             } else {
                 printf("Unknown option: '-%s'\n", cmd);
                 show_usage();
@@ -418,6 +432,10 @@ Config parse_commandline_opts(int argc, char **argv) {
     if (config.tileSize == TILE_8x16 && config.remove_dups) {
         printf("Warning: remove duplicates has been disabled because 8x16 tile size was selected.\n");
         config.remove_dups = false;
+    }
+    if (config.compress && !cfg_output_bin) {
+        printf("Warning: output changed to binary because compression was enabled.\n");
+        cfg_output_bin = true;
     }
 
     return config;
@@ -500,7 +518,22 @@ void write_tiles(Config config, const char *filename, std::vector<Tile *> *tiles
     }
 
     // write binary outbuf to file
-    if (cfg_output_bin) out.write((const char*)outbuf.data(), outbuf.size());
+    int orig_sz = outbuf.size();
+
+    // compress
+    if (config.compress) {
+        uint8_t* comp_dat = (uint8_t*)malloc(orig_sz);
+
+        int comp_sz = PSGaiden_compressTiles(outbuf.data(), size, comp_dat, orig_sz);
+
+        std::cout << "Compressed tile data from " << orig_sz << " bytes to " << comp_sz
+            << " (" << (int)(comp_sz / (float)orig_sz * 100) << "%)." << std::endl;
+
+        out.write((const char*)comp_dat, comp_sz);
+        free(comp_dat); comp_dat = NULL;
+
+    // uncompressed binary
+    } else if (cfg_output_bin) out.write((const char*)outbuf.data(), orig_sz);
 
     out.close();
 }
@@ -523,8 +556,8 @@ void write_sms_palette_file(const char *filename, Image *input_image) {
         uint8_t c = (convert_colour_channel_to_2bit((uint8_t) input_image->palette[i].red)
                    | (convert_colour_channel_to_2bit((uint8_t) input_image->palette[i].green) << 2)
                    | (convert_colour_channel_to_2bit((uint8_t) input_image->palette[i].blue) << 4));
-        char buf[3];
         if (!cfg_output_bin) {
+            char buf[3];
             sprintf(buf, "%02X", c);
             out << " $" << buf;
         } else out.write((const char*)&c, 1);
@@ -545,8 +578,8 @@ void write_gg_palette_file(const char *filename, Image *input_image) {
         uint16_t c = ((uint16_t) input_image->palette[i].red >> 4)
                    | (uint16_t) (input_image->palette[i].green >> 4) << 4
                    | (uint16_t) (input_image->palette[i].blue >> 4) << 8;
-        char buf[5];
         if (!cfg_output_bin) {
+            char buf[5];
             sprintf(buf, "%04X", c);
             out << " $" << buf;
         } else out.write((const char*)&c, 2);
@@ -567,8 +600,8 @@ void write_gen_palette_file(const char *filename, Image *input_image) {
         uint16_t c = (uint16_t)(((input_image->palette[i].red >> 4) & 0xE) << 0)
             | (uint16_t)(((input_image->palette[i].green >> 4) & 0xE) << 4)
             | (uint16_t)(((input_image->palette[i].blue >> 4) & 0xE) << 8);
-        char buf[5];
         if (!cfg_output_bin) {
+            char buf[5];
             sprintf(buf, "%04X", c);
             out << " $" << buf;
         } else out.write((const char*)&c, 2);
@@ -711,8 +744,8 @@ void write_tilemap_file(Config config, const char *filename, std::vector<Tile *>
             id = id | TILEMAP_INFRONT_FLAG;
         }
 
-        char buf[5];
         if (!cfg_output_bin) {
+            char buf[5];
             sprintf(buf, "%04X", id);
             out << " $" << buf;
         }
@@ -729,7 +762,22 @@ void write_tilemap_file(Config config, const char *filename, std::vector<Tile *>
     }
 
     // write binary outbuf to file
-    if (cfg_output_bin) out.write((const char*)outbuf.data(), outbuf.size() * 2);
+    int orig_sz = outbuf.size() * 2;
+
+    // compress
+    if (config.compress) {
+        uint8_t* comp_dat = (uint8_t*)malloc(orig_sz);
+
+        int comp_sz = STM_compressTilemap((uint8_t*)outbuf.data(), width, height, comp_dat, orig_sz);
+
+        std::cout << "Compressed tilemap from " << orig_sz << " bytes to " << comp_sz
+            << " (" << (int)(comp_sz / (float)orig_sz * 100) << "%)." << std::endl;
+
+        out.write((const char*)comp_dat, comp_sz);
+        free(comp_dat); comp_dat = NULL;
+
+    // uncompressed binary
+    } else if (cfg_output_bin) out.write((const char*)outbuf.data(), orig_sz);
 
     out.close();
 }
@@ -853,6 +901,9 @@ void add_new_tile(std::vector<Tile *> *tiles, Tile *tile) {
 }
 
 void process_file(Config config) {
+    // some extra verbosity
+    printf("Processing \"%s\"...\n", config.input_filename);
+
     Image *image = read_png_file(config.input_filename);
     if (image == NULL) {
         return;


### PR DESCRIPTION
This adds a -compress option for compressing binary output files. It uses STM compression by sverx for Tilemaps and PSGaiden compression by maxim for Tile data. I included the original compressor sources from BMP2Tile and modified them for statically building. Using -compress also implies -binary and prints a warning message if it wasn't also specified. Also added some verbosity by printing the current filename being processed as well as file size results when using compression.

Comments / suggestions are welcome. Thanks.
