### PR TITLE
Add -quiet option to remove non-error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ https://github.com/yuv422/png2tile
                          Compress output binary files. Uses STM compression for tilemaps
                          and PSG compression for tiles. Implies -binary if not also specified.
 
+    -quiet               Reduce verbosity.
+
 ## Compiling png2tile
 
 png2tile uses `CMake`.


### PR DESCRIPTION
This patch adds support for a -quiet command-line option which disables output messages, such has the tilemap and tiles size summary and compression ratio.

It also disables one warning which I get for pretty much all the files my artist sends me:
`[read_png_file] PNG bit depth > 4. Only the first 16 colours will be used`

I felt that it was reasonable to disable this warning about the bit depth given that 1. it is only a problem if more than 16 colors are used, and 2. when it happens, the code a few lines later issues warnings for every single pixel that has an index value past 16. (i.e. png2tile will not be silent when there is a real problem)

Other errors and warnings are still displayed.